### PR TITLE
Fixed a typo solution-wide: "bApplyStanima" -> "bApplyStamina".

### DIFF
--- a/Chihiro/src/Entities/Player/Player.cpp
+++ b/Chihiro/src/Entities/Player/Player.cpp
@@ -2809,7 +2809,7 @@ bool Player::EraseBullet(int64 count)
     return false;
 }
 
-void Player::AddEXP(int64 exp, uint jp, bool bApplyStanima)
+void Player::AddEXP(int64 exp, uint jp, bool bApplyStamina)
 {
     // @todo immoral
 
@@ -2820,7 +2820,7 @@ void Player::AddEXP(int64 exp, uint jp, bool bApplyStanima)
     int   bonus_jp  = 0;
     if (exp != 0)
     {
-        if (bApplyStanima)
+        if (bApplyStamina)
         {
             gain_exp = (int64)((float)gain_exp / GameRule::GetStaminaRatio(GetLevel()));
             auto s   = GetStamina();

--- a/Chihiro/src/Entities/Player/Player.h
+++ b/Chihiro/src/Entities/Player/Player.h
@@ -224,7 +224,7 @@ class Player : public Unit, public QuestEventHandler, public InventoryEventRecei
         bool CheckTradeWeight();
         bool CheckTradeItem();
 
-        void AddEXP(int64 exp, uint jp, bool bApplyStanima) override;
+        void AddEXP(int64 exp, uint jp, bool bApplyStamina) override;
         uint16_t putonItem(ItemWearType, Item *) override;
         uint16_t putoffItem(ItemWearType) override;
         void SendItemWearInfoMessage(Item *item, Unit *u);

--- a/Chihiro/src/Entities/Unit/Unit.cpp
+++ b/Chihiro/src/Entities/Unit/Unit.cpp
@@ -1284,7 +1284,7 @@ void Unit::onDead(Unit *pFrom, bool decreaseEXPOnDead)
     m_vStateList.clear();
 }
 
-void Unit::AddEXP(int64 exp, uint jp, bool bApplyStanima)
+void Unit::AddEXP(int64 exp, uint jp, bool bApplyStamina)
 {
     SetUInt64Value(UNIT_FIELD_EXP, GetEXP() + exp);
     SetUInt32Value(UNIT_FIELD_JOBPOINT, GetJP() + jp);

--- a/Chihiro/src/Entities/Unit/Unit.h
+++ b/Chihiro/src/Entities/Unit/Unit.h
@@ -253,7 +253,7 @@ class Unit : public WorldObject
 
         void AddMana(int mp) { SetMana(GetMana() + mp); }
 
-        virtual void AddEXP(int64 exp, uint jp, bool bApplyStanima);
+        virtual void AddEXP(int64 exp, uint jp, bool bApplyStamina);
         void CancelSkill();
         void CancelAttack();
         int CastSkill(int nSkillID, int nSkillLevel, uint target_handle, Position pos, uint8 layer, bool bIsCastedByItem);


### PR DESCRIPTION
Commit sums it up, simply changes 5 bool entities to fix an infamous typo.