### PR TITLE
ASIO: use reuse_address to avoid binding issues

### DIFF
--- a/shared/Server/ASIO/AsyncAcceptor.h
+++ b/shared/Server/ASIO/AsyncAcceptor.h
@@ -81,6 +81,9 @@ class AsyncAcceptor
                 return false;
             }
 
+            boost::asio::socket_base::reuse_address option(true);
+            _acceptor.set_option(option);
+
             _acceptor.bind(_endpoint, errorCode);
             if (errorCode)
             {


### PR DESCRIPTION
REUSE_ADDRESS won't avoid TIME_WAIT states, but will allow the server to bind anyway (while without it, it would fail).