### PR TITLE
Implemented GameServer.External_IP

### DIFF
--- a/Chihiro/src/Network/AuthNetwork/AuthNetwork.h
+++ b/Chihiro/src/Network/AuthNetwork/AuthNetwork.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *  Copyright (C) 2017-2020 NGemity <https://ngemity.org/>
+ *  Copyright (C) 2017-2019 NGemity <https://ngemity.org/>
  *
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/Chihiro/src/Network/AuthNetwork/GameAuthSession.h
+++ b/Chihiro/src/Network/AuthNetwork/GameAuthSession.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *  Copyright (C) 2017-2020 NGemity <https://ngemity.org/>
+ *  Copyright (C) 2017-2019 NGemity <https://ngemity.org/>
  *
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the
@@ -56,5 +56,6 @@ private:
   std::string m_szGameSSU;
   bool m_bGameIsAdultServer;
   std::string m_szGameIP;
+  std::string m_szExtGameIP;
   int32_t m_nGamePort;
 };

--- a/shared/Server/Packets/AuthClient/TS_AC_SERVER_LIST.h
+++ b/shared/Server/Packets/AuthClient/TS_AC_SERVER_LIST.h
@@ -9,6 +9,7 @@
     _(simple) (uint8_t, is_adult_server, version >= EPIC_4_1, false) \
     _(string) (server_screenshot_url, 256, version >= EPIC_4_1, "about:blank") \
     _(string) (server_ip, 16) \
+    _(string) (server_external_ip, 16) \
     _(simple) (int32_t, server_port) \
     _(simple) (uint16_t, user_ratio)
 

--- a/shared/Server/Packets/AuthGame/TS_GA_LOGIN.h
+++ b/shared/Server/Packets/AuthGame/TS_GA_LOGIN.h
@@ -9,6 +9,7 @@
     _(string)(server_screenshot_url, 256) \
     _(simple)(uint8_t, is_adult_server) \
     _(string)(server_ip, 16) \
+    _(string)(server_external_ip, 16) \
     _(simple)(int32_t, server_port)
 CREATE_PACKET(TS_GA_LOGIN, 20001);
 


### PR DESCRIPTION
- chihiro.conf can not define GameServer.External_IP, if not defined normal behavior can be expected. If defined (e.g. GameServer.External_IP != "0.0.0.0") Chihiro will send GameServer.External_IP as its listening ip even though Chihiro is actually listening on 0.0.0.0 (fixes communications bugs in use case like Manjaro Pi4B aarch64)